### PR TITLE
persist current map and layer to querystring for easier sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,9 +194,15 @@
 
     function ddSelectLayer(map, layer) {
         layerButton.innerHTML = layer;
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.set("map", map);
+        searchParams.set("layer", layer);
+        if (searchParams.toString() !== window.location.search.substr(1)) {
+            history.pushState({}, '', '?' + searchParams.toString());
+        }
         changeMap(map, layer);
     }
-
+    
     document.addEventListener('DOMContentLoaded', function () {
         mapButton.addEventListener('mouseenter', () => {
             mapMenu.classList.toggle("shown", true);
@@ -209,7 +215,13 @@
             for (const map in raasData) {
                 mapMenu.innerHTML += `<a class="dropdown-item text-light" href="#" onmousedown="ddSelectMap('${map}')">${map}</a>`;
             }
-            ddSelectMap("Narva");
+            const searchParams = new URLSearchParams(window.location.search);
+            const map = searchParams.get('map');
+            const layer = searchParams.get('layer');
+
+            // we always need to call ddSelectMap to set currently selected map and the layer dropdown items
+            ddSelectMap(map || 'Narva');
+            layer && ddSelectLayer(map, layer);
         })
 
         if (window.location.hostname.startsWith("dev.")) {

--- a/index.html
+++ b/index.html
@@ -167,6 +167,7 @@
     const mapButton = document.getElementById("dropDownMapButton");
     const layerMenu = document.getElementById("dropDownLayerMenu");
     const layerButton = document.getElementById("dropDownLayerButton");
+    const DEFAULT_MAP = "Narva";
 
     function ddSelectMap(map) {
         mapButton.innerHTML = map;
@@ -200,29 +201,53 @@
         if (searchParams.toString() !== window.location.search.substr(1)) {
             history.pushState({}, '', '?' + searchParams.toString());
         }
-        changeMap(map, layer);
+    }
+        
+    function handleQueryStringErrors(callback) {
+        try {
+            return callback();
+        } catch(error) {
+            const shouldCatchErrorAndResetQueryParams = !![
+                MapNotFoundError,
+                LayerNotFoundError,
+            ].find((errorType) => error instanceof errorType);
+            
+            if (shouldCatchErrorAndResetQueryParams) {
+                alert(error);
+                ddSelectMap(DEFAULT_MAP);
+            } else {
+                throw error;
+            }
+        }
     }
     
     document.addEventListener('DOMContentLoaded', function () {
         mapButton.addEventListener('mouseenter', () => {
             mapMenu.classList.toggle("shown", true);
-        })
+        });
         mapButton.addEventListener('mouseleave', () => {
             mapMenu.classList.toggle("shown", false);
-        })
+        });
         onRaasDataLoad(() => {
             mapMenu.innerHTML = "";
             for (const map in raasData) {
                 mapMenu.innerHTML += `<a class="dropdown-item text-light" href="#" onmousedown="ddSelectMap('${map}')">${map}</a>`;
             }
             const searchParams = new URLSearchParams(window.location.search);
-            const map = searchParams.get('map');
+            const map = searchParams.get('map') || DEFAULT_MAP;
             const layer = searchParams.get('layer');
 
-            // we always need to call ddSelectMap to set currently selected map and the layer dropdown items
-            ddSelectMap(map || 'Narva');
-            layer && ddSelectLayer(map, layer);
-        })
+            handleQueryStringErrors(() => {
+                validateMapName(map);
+                // we always need to call ddSelectMap to set currently selected map and the layer dropdown items
+                ddSelectMap(map);
+                
+                if (layer) {
+                  validateLayerName(map, layer);  
+                  ddSelectLayer(map, layer);
+                } 
+            });
+        });
 
         if (window.location.hostname.startsWith("dev.")) {
             loadRaasData("raas-data-dev.yaml", () => {});

--- a/index.html
+++ b/index.html
@@ -201,6 +201,7 @@
         if (searchParams.toString() !== window.location.search.substr(1)) {
             history.pushState({}, '', '?' + searchParams.toString());
         }
+        changeMap(map, layer);
     }
         
     function handleQueryStringErrors(callback) {

--- a/js/map.js
+++ b/js/map.js
@@ -630,3 +630,20 @@ function changeMap(mapName, layerName) {
         });
     }).observe(mapDiv);
 }
+
+function validateMapName(map) {
+    if (!raasData[map]) {
+        throw new MapNotFoundError(`No map found named ${map}`);
+    }
+    return true;
+}
+
+function validateLayerName(map, layer) {
+    if (!raasData[map][layer]) {
+        throw new LayerNotFoundError(`No layer for ${map} found named ${layer}`);
+    }
+    return true;
+}
+
+class MapNotFoundError extends Error {}
+class LayerNotFoundError extends Error {}


### PR DESCRIPTION
Hey, thanks for making this tool, I'm finding it really useful.

Other tools that perform a similar role to this one will often save the state of the UI to query parameters to make sharing and referencing specific situations easier.

This PR implements a small change to add this functionality, though only to the map and layer parameters.

If you think this could be a useful feature and want to go in this direction, I could add more fine-grained parameters for the specific lane, team perspective and capture-point numbers, though I might need some help deciding what variables would actually be useful to include.

I'm also open to any improvements/tweaks to the current implementation. For example, the current implementation doesn't deal with query parameters with incorrect or stale data, so things might break in that case. If it's important to you that we avoid this, I can add some validation and just delete bad query parameters or display some error message. 
