### PR TITLE
Feature/scroll dropdowns - make dropdowns scroll and stop focusing map filter input on mobile 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "startbootstrap-simple-sidebar",
     "version": "5.1.2",
     "scripts": {
-        "start": "node_modules/.bin/gulp watch",
+        "start": "node_modules/.bin/parcel src/index.html",
         "format": "node_modules/.bin/prettier --write src",
         "format-check": "node_modules/.bin/prettier --check src"
     },

--- a/src/LayerSelect.vue
+++ b/src/LayerSelect.vue
@@ -146,4 +146,9 @@ export default Vue.extend({
 #layer-dropdown {
   flex-grow: 0.2;
 }
+
+.dropdown-menu {
+  max-height: 100vh;
+  overflow-y: auto;
+}
 </style>

--- a/src/LayerSelect.vue
+++ b/src/LayerSelect.vue
@@ -43,7 +43,7 @@ import Vue from "vue";
 import { BootstrapVue, IconsPlugin } from "bootstrap-vue";
 import "bootstrap/dist/css/bootstrap";
 import "bootstrap-vue/dist/bootstrap-vue";
-import {isSmallTouchDevice} from './utils';
+import { isSmallTouchDevice } from "./utils";
 
 Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
@@ -73,9 +73,7 @@ export default Vue.extend({
     this.$root.$on("bv::dropdown::shown", (bvEvent) => {
       this.filterMapInputValue = "";
       this.filterMap();
-      console.log('is small: ', isSmallTouchDevice());
       if (!isSmallTouchDevice()) {
-        console.log({refs: this.$refs});
         var input = this.$refs.filterMapInputRef;
         setTimeout(() => input.$el.focus(), 10);
       }

--- a/src/LayerSelect.vue
+++ b/src/LayerSelect.vue
@@ -43,6 +43,7 @@ import Vue from "vue";
 import { BootstrapVue, IconsPlugin } from "bootstrap-vue";
 import "bootstrap/dist/css/bootstrap";
 import "bootstrap-vue/dist/bootstrap-vue";
+import {isSmallTouchDevice} from './utils';
 
 Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
@@ -72,8 +73,12 @@ export default Vue.extend({
     this.$root.$on("bv::dropdown::shown", (bvEvent) => {
       this.filterMapInputValue = "";
       this.filterMap();
-      var input = this.$refs.filterMapInputRef;
-      setTimeout(() => input.$el.focus(), 10);
+      console.log('is small: ', isSmallTouchDevice());
+      if (!isSmallTouchDevice()) {
+        console.log({refs: this.$refs});
+        var input = this.$refs.filterMapInputRef;
+        setTimeout(() => input.$el.focus(), 10);
+      }
     });
 
     this.keyListener = (e) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,18 @@
 export function isSmallTouchDevice() {
-  const vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
-  return (vh <= 760 && isTouchDevice());
+  const vh = Math.max(
+    document.documentElement.clientHeight || 0,
+    window.innerHeight || 0
+  );
+  return vh <= 760 && isTouchDevice();
 }
 
 /**
  * Taken from https://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript
  **/
 function isTouchDevice() {
-  return (('ontouchstart' in window) ||
-     (navigator.maxTouchPoints > 0) ||
-     (navigator.msMaxTouchPoints > 0));
+  return (
+    "ontouchstart" in window ||
+    navigator.maxTouchPoints > 0 ||
+    navigator.msMaxTouchPoints > 0
+  );
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+export function isSmallTouchDevice() {
+  const vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
+  return (vh <= 760 && isTouchDevice());
+}
+
+/**
+ * Taken from https://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript
+ **/
+function isTouchDevice() {
+  return (('ontouchstart' in window) ||
+     (navigator.maxTouchPoints > 0) ||
+     (navigator.msMaxTouchPoints > 0));
+}


### PR DESCRIPTION
On small displays the bootstrap 4 dropdown can clip out of the viewport, which is very likely to happen on mobile aspect ratios with onscreen keyboards. This PR adds some simple styles to prevent this from happening on the maps dropdown as well as preventing input focus on mobile to avoid the onscreen keyboard from hiding some of the maps when the dropdown is opened.